### PR TITLE
Fixed Displaying of Icon

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIconFile</key>
+        <string>Burp.icns</string>
+</dict>
+</plist>


### PR DESCRIPTION
Removed the Icon file signifying that a local custom Icon had been set.   More info here:

http://superuser.com/a/298798

Created a small plist file to point to the actual Burp.icns file.

Now Burp icon displays by default.
